### PR TITLE
Added trace for seeing the execution of large tactics

### DIFF
--- a/src/tacticals.fun
+++ b/src/tacticals.fun
@@ -61,6 +61,8 @@ struct
     ORELSE(tac, ID)
 
   fun REPEAT tac = TRY (THEN_LAZY (tac, fn () => TRY (REPEAT tac)))
+
+  fun TRACE s = THEN_LAZY (ID, fn () => (print (s ^ "\n"); ID))
 end
 
 functor ProgressTacticals (Lcf : LCF_APART) : PROGRESS_TACTICALS =

--- a/src/tacticals.sig
+++ b/src/tacticals.sig
@@ -13,6 +13,11 @@ sig
   val ORELSE : tactic * tactic -> tactic
   val ORELSE_LAZY : tactic * (unit -> tactic) -> tactic
   val TRY : tactic -> tactic
+
+  (* TRACE s will print out s to the console when run and then behave
+   * like ID
+   *)
+  val TRACE : string -> tactic
 end
 
 signature PROGRESS_TACTICALS =


### PR DESCRIPTION
Added a tactic for tracing called `TRACE`. It accepts a string and prints it when it is run. Otherwise it behaves as `ID`.
