### PR TITLE
Added tactics for "focusing" a tactic on a new subgoal

### DIFF
--- a/src/tacticals.fun
+++ b/src/tacticals.fun
@@ -155,7 +155,7 @@ struct
     THEN_LAZY (tac1, fn () => tac2)
 
   fun THENF (tac1, i, tac2) =
-      THENF_LAZY (tac1, i, fn () => tac2)
+    THENF_LAZY (tac1, i, fn () => tac2)
 
   (* TODO: Should ORELSE_LAZY have some idea of
    * how to keep track of failing tactics to present

--- a/src/tacticals.sig
+++ b/src/tacticals.sig
@@ -44,7 +44,17 @@ sig
    *)
   val THENL_LAZY : tactic * (unit -> tactic list) -> tactic
 
+  (* THENF (t1, i, t2) runs t1 and then runs t2 on the ith subgoal
+   * produced by t1. All the other subgoals are left untouched and
+   * if t2 produces any subgoals of its own they are merged into the
+   * list of remaining subgoals. If t1 produces subgoals but doesn't produce
+   * at least i of them this fails.
+   *)
   val THENF : tactic * int * tactic -> tactic
+
+  (* This behaves as THENF does but will not evaluate the supplied tactic
+   * if t1 doesn't produce any subgoals.
+   *)
   val THENF_LAZY : tactic * int * (unit -> tactic) -> tactic
 
   (* REPEAT t will run a tactic over and over again. It can be thought

--- a/src/tacticals.sig
+++ b/src/tacticals.sig
@@ -44,6 +44,9 @@ sig
    *)
   val THENL_LAZY : tactic * (unit -> tactic list) -> tactic
 
+  val THENF : tactic * int * tactic -> tactic
+  val THENF_LAZY : tactic * int * (unit -> tactic) -> tactic
+
   (* REPEAT t will run a tactic over and over again. It can be thought
    * of THEN (t, THEN (t, (Then t, ...))).
    *


### PR DESCRIPTION
This makes it so you can apply a tactic and immediately apply another tactic to _one_ of the outputted subgoals of the original tactic. This will let us express `t1; [id, id, ..., t2, id, id, ...]` in JonPRL much more nicely.
