### PR TITLE
Add a pruning tactical

### DIFF
--- a/lcf.cm
+++ b/lcf.cm
@@ -3,12 +3,14 @@ Library
   signature TACTICALS
   signature LCF_APART
   signature PROGRESS_TACTICALS
+  signature TRANSFORMATIONAL_TACTICALS
 
   signature ANNOTATED_LCF
   functor AnnotatedLcf
 
   functor Tacticals
   functor ProgressTacticals
+  functor TransformationalTacticals
 is
   $/basis.cm
   src/lcf.sig

--- a/lcf.mlb
+++ b/lcf.mlb
@@ -13,7 +13,9 @@ in
   signature LCF_APART
   signature PROGRESS_TACTICALS
   signature ANNOTATED_LCF
+  signature TRANSFORMATIONAL_TACTICALS
   functor AnnotatedLcf
   functor Tacticals
   functor ProgressTacticals
+  functor TransformationalTacticals
 end

--- a/src/tacticals.fun
+++ b/src/tacticals.fun
@@ -219,7 +219,7 @@ struct
                    case Int.compare (j, i) of
                         EQUAL => i
                       | LESS => alpha j
-                      | GREATER => alpha j - 1)
+                      | GREATER => alpha (j - 1))
       val (xs', alpha) = go xs ([], fn i => i)
     in
       (xs', fn ys => List.tabulate (length xs, fn i => List.nth (ys, alpha i)))

--- a/src/tacticals.fun
+++ b/src/tacticals.fun
@@ -189,6 +189,51 @@ struct
   fun TRACE s = THEN_LAZY (ID, fn () => (print (s ^ "\n"); ID))
 end
 
+functor TransformationalTacticals (Lcf : LCF_APART) : TRANSFORMATIONAL_TACTICALS =
+struct
+  open Lcf
+  exception XX
+
+  local
+    fun go i ([], x) = NONE
+      | go i (y::xs, x) =
+          if goalApart (x,y) then
+            go (i + 1) (xs, x)
+          else
+            SOME i
+  in
+    val findIndex = go 0
+  end
+
+  type 'a endo = 'a ->'a
+  type ev_deform = evidence list endo
+
+  fun prune (xs : goal list) : goal list * ev_deform =
+    let
+      fun go [] (R, alpha) = (R, alpha)
+        | go (y::ys) (R, alpha) =
+          case findIndex (R, y) of
+               NONE => go ys (R @ [y], alpha)
+             | SOME i =>
+                 go ys (R, fn j =>
+                   case Int.compare (j, i) of
+                        EQUAL => i
+                      | LESS => alpha j
+                      | GREATER => alpha j - 1)
+      val (xs', alpha) = go xs ([], fn i => i)
+    in
+      (xs', fn ys => List.tabulate (length xs, fn i => List.nth (ys, alpha i)))
+    end
+
+  fun PRUNE tac g =
+    let
+      val (subgoals, validation) = tac g
+      val (subgoals', transform) = prune subgoals
+    in
+      (subgoals', validation o transform)
+    end
+end
+
 functor ProgressTacticals (Lcf : LCF_APART) : PROGRESS_TACTICALS =
 struct
   structure Tacticals = Tacticals (Lcf)

--- a/src/tacticals.sig
+++ b/src/tacticals.sig
@@ -105,6 +105,14 @@ sig
   val TRACE : string -> tactic
 end
 
+signature TRANSFORMATIONAL_TACTICALS =
+sig
+  type tactic
+
+  (* Run a tactic, but prune out redundant subgoals *)
+  val PRUNE : tactic -> tactic
+end
+
 signature PROGRESS_TACTICALS =
 sig
   type tactic


### PR DESCRIPTION
This is an interesting little tactical that takes the subgoals of its argument and collapses them to remove duplicates.

[One interesting thing to try would be to allow clients to assign an order on goals, and then the strongest goal is favored. I'll hold off on that idea though...]
